### PR TITLE
Update requirement utool to wbia-utool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS        = [
     'six',
     'theano',
     'tqdm',
-    'utool',
+    'wbia-utool',
 ]
 
 


### PR DESCRIPTION
We renamed the distribution name of utool to wbia-utool.