### PR TITLE
Remove cv2 import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,20 +99,6 @@ __version_full__ = '%%s.%%s' %% (__version__, __version_git__, )
 
 
 def do_setup():
-    try:
-        import cv2  # NOQA
-    except ImportError:
-        print(
-            """
-OpenCV (cv2) required by this module.
-
-Install using source provided by https://github.com/opencv/opencv
-or
-pip install opencv-python
-"""
-        )
-        sys.exit(0)
-
     install_requires = parse_requirements('requirements/runtime.txt')
     extras_require = {
         'all': parse_requirements('requirements.txt'),


### PR DESCRIPTION
We import `cv2` in setup.py to check that `opencv` is installed... but
without `opencv-python` in `pyproject.toml` build requirements, the
package fails to install:

```
+ cd /wbia/wbia-plugin-curvrank
+ /bin/bash unix_build.sh
g++ astar.cpp -o astar.so -O3 -Wall -shared -fpic
g++ -I/usr/include/eigen3 dtw.cpp -o dtw.so -O3 -Wall -shared -fpic
Obtaining file:///wbia/wbia-plugin-curvrank
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
ERROR: Could not install packages due to an EnvironmentError: [Errno 2] No such file or directory: '/tmp/tmpkt5ou6ho/output.json'
```

So let's just remove the `cv2` import.
