### PR TITLE
Remove lasagne from requirements, use wbia-cnn instead

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,7 +1,7 @@
 annoy
 # cv2
 h5py
-lasagne
+# lasagne # use the one embedded in wbia-cnn
 luigi
 matplotlib
 numpy
@@ -10,4 +10,5 @@ scipy
 six
 theano
 tqdm
+wbia-cnn
 wbia-utool


### PR DESCRIPTION
We have embedded lasagne in wbia-cnn because the version of lasagne on
pypi is too old and we don't want to install from github because pypi
doesn't allow it.